### PR TITLE
Server actions for submission related operations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,8 +21,25 @@ model Question {
   reference_program    String   @unique
   course               Course   @relation(fields: [courseId], references: [id])
   courseId             String
+  submissions          Submission[]
 
   @@map("questions")
+}
+
+model Submission {
+
+  id                   String   @id @unique @default(cuid())
+  submit_time          DateTime @default(now())
+  question             Question @relation(fields: [question_id], references: [id])
+  question_id          String
+  user                 User     @relation(fields: [user_id], references: [id])
+  user_id              String
+  submitted_program    String   // tbc
+  feedback             String?  // tbc
+  grade                Int?     // tbc
+  // more columns as necessary
+
+  @@map("submissions")
 }
 
 enum Role {
@@ -32,15 +49,16 @@ enum Role {
 }
 
 model User {
-  id            String    @id @default(uuid())
-  email         String?   @unique
-  password      String?
-  role          Role?
-  school        School   @relation(fields: [school_id], references: [id])
-  school_id     String
-  accounts      Account[]
-  created_courses Course[] @relation("course_creator")
-  joined_courses Course[]  @relation("course_members")
+  id                   String    @id @default(uuid())
+  email                String?   @unique
+  password             String?
+  role                 Role?
+  school               School    @relation(fields: [school_id], references: [id])
+  school_id            String
+  accounts             Account[]
+  created_courses      Course[]  @relation("course_creator")
+  joined_courses       Course[]  @relation("course_members")
+  submissions          Submission[]
 
   @@map("users")
 }

--- a/src/actions/createSubmission.ts
+++ b/src/actions/createSubmission.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function createSubmission({ 
+  user_email, 
+  question_id, 
+  submitted_program 
+}: { 
+  user_email: string, 
+  question_id: string, 
+  submitted_program: string 
+}) {
+    try {
+      const user = await prisma.user.findUnique({
+        where: {
+          email: user_email,
+        },
+      });
+  
+      if (!user) {
+        return null;
+      }
+
+      const question = await prisma.question.findUnique({
+        where: {
+          id: question_id,
+        },
+        include: {
+            submissions: true,
+        },
+      });
+
+      const newSubmission = await prisma.submission.create({
+        data: {
+          user_id: user.id,
+          question_id: question_id,
+          submitted_program: submitted_program,
+        },
+      });
+  
+      const existingSubmissions = question?.submissions || [];
+      const updatedSubmissions = [...existingSubmissions, newSubmission];
+  
+      await prisma.question.update({
+        where: {
+          id: question?.id,
+        },
+        data: {
+          submissions: {
+            set: updatedSubmissions
+          }
+        },
+      });
+
+      return newSubmission;
+
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  

--- a/src/actions/getMySubmissions.ts
+++ b/src/actions/getMySubmissions.ts
@@ -1,0 +1,36 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function getMySubmissions({ 
+  question_id, 
+  user_email 
+}: { 
+  question_id: string, 
+  user_email: string 
+}) {
+    try {
+      const user = await prisma.user.findUnique({
+        where: {
+          email: user_email,
+        },
+        include: {
+          submissions: true,
+        }
+      })
+  
+      if (!user) {
+        return null;
+      }
+
+      const questionSubmissions = user.submissions.filter(submission => 
+        submission.question_id === question_id
+      )
+
+      return questionSubmissions;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  

--- a/src/actions/getQuestionSubmissions.ts
+++ b/src/actions/getQuestionSubmissions.ts
@@ -1,0 +1,26 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function getQuestionSubmissions({ question_id }: { question_id: string }) {
+    try {
+      const question = await prisma.question.findUnique({
+        where: {
+          id: question_id,
+        },
+        include: {
+          submissions: true,
+        }
+      })
+  
+      if (!question) {
+        return null;
+      }
+
+      return question.submissions;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  

--- a/src/actions/getSubmission.ts
+++ b/src/actions/getSubmission.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function getSubmission({ submission_id }: { submission_id: string }) {
+    try {
+      const submission = await prisma.submission.findUnique({
+        where: {
+          id: submission_id,
+        },
+      })
+  
+      if (!submission) {
+        return null;
+      }
+
+      return submission;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  

--- a/src/actions/setSubmissionFeedback.ts
+++ b/src/actions/setSubmissionFeedback.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function setSubmissionFeedback({ 
+  submission_id, 
+  feedback 
+}: { 
+  submission_id: string, 
+  feedback: string 
+}) {
+    try {
+      const submission = await prisma.submission.update({
+        where: {
+          id: submission_id,
+        },
+        data: {
+            feedback: feedback,
+        },
+      })
+  
+      if (!submission) {
+        return null;
+      }
+
+      return submission;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  

--- a/src/actions/setSubmissionGrade.ts
+++ b/src/actions/setSubmissionGrade.ts
@@ -1,0 +1,42 @@
+"use server";
+
+import prisma from "@/lib/prisma";
+
+export async function setSubmissionGrade({ 
+  submission_id, 
+  grade 
+}: { 
+  submission_id: string, 
+  grade: number
+}) {
+    try {
+      if (!Number.isInteger(grade)) {
+        console.error("Invalid grade format");
+        return null;
+      }
+
+      if (grade < 0 || grade > 100) {
+        console.error("Grade awarded is out of range");
+        return null;
+      }
+
+      const submission = await prisma.submission.update({
+        where: {
+          id: submission_id,
+        },
+        data: {
+            grade: grade,
+        },
+      })
+  
+      if (!submission) {
+        return null;
+      }
+
+      return submission;
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
+  }
+  


### PR DESCRIPTION
Using server actions instead of API routes. Open to changes

Methods:
Create submission
Get specific submission
Get all submissions for specific question (for teacher use)
Get all submissions for specific student's question (for student use)
Update submission feedback (after ITS returns feedback)
Update submission grade (teacher manual grade)

@thennant @danielk0k check if it is missing something you guys need